### PR TITLE
Fix auto-release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+      - "v*.*.rc*"
+      - "v*.*.*.rc*"
 
 jobs:
   create-release:
@@ -13,11 +15,51 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version info
+        id: version
+        run: |
+          TAG_NAME="${{ github.ref_name }}"
+          VERSION=${TAG_NAME#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+
+          # Check if this is a prerelease
+          if [[ "$VERSION" == *"rc"* ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+            echo "This is a release candidate"
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+            echo "This is a stable release"
+          fi
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           draft: false
-          prerelease: false
-          name: Release ${{ github.ref_name }}
+          prerelease: ${{ steps.version.outputs.is_prerelease }}
+          name: "Typesense ${{ steps.version.outputs.version }}"
+          body: |
+            ## Typesense ${{ steps.version.outputs.version }}
+
+            🔍 **Search Engine Version**: ${{ steps.version.outputs.version }}
+            📦 **Docker Image**: `typesense/typesense:${{ steps.version.outputs.version }}`
+
+            ### What's Changed
+            This release updates the Typesense search engine to version ${{ steps.version.outputs.version }}.
+
+            ### Docker Usage
+            ```bash
+            docker run -p 8108:8108 -v $(pwd)/typesense-data:/data typesense/typesense:${{ steps.version.outputs.version }} \
+              --data-dir /data --api-key=Hu52dwsas2AdxdE
+            ```
+
+            Or use this containerized version with healthcheck:
+            ```bash
+            docker run -p 8108:8108 ghcr.io/[your-repo]/typesense:${{ steps.version.outputs.tag_name }}
+            ```
+
           generate_release_notes: true
+          make_latest: ${{ steps.version.outputs.is_prerelease == 'false' }}


### PR DESCRIPTION
- Update tag patterns to support RC versions (v*.*.rc*, v*.*.*.rc*)
- Add automatic prerelease detection for RC versions
- Enhance release description with Docker usage instructions
- Add version extraction and better release naming
- Set make_latest only for stable releases