### PR TITLE
Fix: Improve release workflow reliability

### DIFF
--- a/.github/workflows/release-manager.yaml
+++ b/.github/workflows/release-manager.yaml
@@ -40,16 +40,50 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
+          # Multiple methods to detect Dockerfile changes for reliability
+          DOCKERFILE_CHANGED=false
+          
+          # Method 1: Check current commit vs previous
           if git diff --name-only HEAD~1 HEAD | grep -q "Dockerfile"; then
+            echo "🔍 Dockerfile changed in current commit (HEAD~1..HEAD)"
+            DOCKERFILE_CHANGED=true
+          fi
+          
+          # Method 2: Check if this is a merge commit and look at merge changes
+          if [ "$DOCKERFILE_CHANGED" = false ] && git show --name-only --format="" HEAD | grep -q "Dockerfile"; then
+            echo "🔍 Dockerfile changed in merge commit"
+            DOCKERFILE_CHANGED=true
+          fi
+          
+          # Method 3: Check last 3 commits for Dockerfile changes (fallback)
+          if [ "$DOCKERFILE_CHANGED" = false ] && git diff --name-only HEAD~3 HEAD | grep -q "Dockerfile"; then
+            echo "🔍 Dockerfile changed in recent commits (HEAD~3..HEAD)"
+            DOCKERFILE_CHANGED=true
+          fi
+          
+          # Method 4: Force detection if manual trigger with force_create
+          if [ "$DOCKERFILE_CHANGED" = false ] && [ "${{ github.event.inputs.force_create }}" = "true" ]; then
+            echo "🔍 Force create enabled - treating as Dockerfile changed"
+            DOCKERFILE_CHANGED=true
+          fi
+          
+          if [ "$DOCKERFILE_CHANGED" = true ]; then
             echo "dockerfile=true" >> $GITHUB_OUTPUT
+            echo "✅ Dockerfile changes detected"
           else
             echo "dockerfile=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ No Dockerfile changes detected"
           fi
 
-          if git diff --name-only HEAD~1 HEAD | grep -qE "(Taskfile.yaml|README.md|docs/)"; then
+          # Check for documentation changes
+          if git diff --name-only HEAD~1 HEAD | grep -qE "(Taskfile.yaml|README.md|docs/)" || \
+             git show --name-only --format="" HEAD | grep -qE "(Taskfile.yaml|README.md|docs/)" || \
+             git diff --name-only HEAD~3 HEAD | grep -qE "(Taskfile.yaml|README.md|docs/)"; then
             echo "docs=true" >> $GITHUB_OUTPUT
+            echo "✅ Documentation changes detected"
           else
             echo "docs=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ No documentation changes detected"
           fi
 
       - name: Extract version info
@@ -86,6 +120,7 @@ jobs:
     if: needs.detect-changes.outputs.dockerfile_changed == 'true' && needs.detect-changes.outputs.should_skip != 'true'
     permissions:
       contents: write
+      actions: write
     outputs:
       tag_created: ${{ steps.tag.outputs.created }}
       tag_name: ${{ steps.tag.outputs.name }}
@@ -134,6 +169,31 @@ jobs:
           echo "created=true" >> $GITHUB_OUTPUT
           echo "name=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "✅ Created and pushed ${{ needs.detect-changes.outputs.release_type }} tag: $TAG_NAME"
+
+      - name: Trigger Release Publisher
+        if: steps.tag.outputs.created == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const tagName = '${{ steps.tag.outputs.name }}';
+            console.log(`🚀 Triggering Release Publisher workflow for tag: ${tagName}`);
+            
+            try {
+              const response = await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'release-publisher.yaml',
+                ref: 'main',
+                inputs: {
+                  tag_name: tagName
+                }
+              });
+              console.log(`✅ Successfully triggered Release Publisher workflow`);
+            } catch (error) {
+              console.error(`❌ Failed to trigger Release Publisher: ${error.message}`);
+              // Don't fail the whole workflow if trigger fails
+              console.log(`ℹ️ You can manually trigger: gh workflow run release-publisher.yaml -f tag_name=${tagName}`);
+            }
 
   manage-rc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem
The `release-publisher.yaml` workflow was not automatically triggering when tags were created programmatically by `release-manager.yaml`.

## Solution
- **Added automatic triggering** of release-publisher workflow after tag creation
- **Improved change detection logic** with multiple fallback methods:
  - Check current commit vs previous (existing)
  - Check merge commit changes (new)
  - Check last 3 commits (fallback)
  - Force detection for manual triggers (new)
- **Added better logging** for debugging workflow execution
- **Fixed permissions** to allow triggering workflows

## Changes
- Enhanced `create-tag` job with automatic workflow triggering
- More robust change detection that handles merge commits
- Better error handling and logging

## Testing
This should fix the issue where tags are created but releases are not automatically published.

Fixes the issue: tags create successfully but GitHub releases are not created automatically.