### PR TITLE
Fix: Add automatic Docker image building after tag creation

### DIFF
--- a/.github/workflows/release-manager.yaml
+++ b/.github/workflows/release-manager.yaml
@@ -195,6 +195,31 @@ jobs:
               console.log(`ℹ️ You can manually trigger: gh workflow run release-publisher.yaml -f tag_name=${tagName}`);
             }
 
+      - name: Trigger Publish Workflow
+        if: steps.tag.outputs.created == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const tagName = '${{ steps.tag.outputs.name }}';
+            console.log(`🐳 Triggering Publish workflow for Docker image building: ${tagName}`);
+            
+            try {
+              const response = await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'publish.yaml',
+                ref: 'main',
+                inputs: {
+                  tag_name: tagName
+                }
+              });
+              console.log(`✅ Successfully triggered Publish workflow for Docker images`);
+            } catch (error) {
+              console.error(`❌ Failed to trigger Publish workflow: ${error.message}`);
+              // Don't fail the whole workflow if trigger fails
+              console.log(`ℹ️ You can manually trigger: gh workflow run publish.yaml -f tag_name=${tagName}`);
+            }
+
   manage-rc:
     runs-on: ubuntu-latest
     needs: [detect-changes, create-tag]


### PR DESCRIPTION
## Problem
When tags are created programmatically by `release-manager.yaml`, the `publish.yaml` workflow was not triggering automatically, resulting in:
- ✅ GitHub releases created
- ❌ Docker images missing

## Root Cause
The `publish.yaml` workflow only triggers on manual tag pushes, not programmatic tag creation.

## Solution
- **Added automatic triggering** of `publish.yaml` workflow after tag creation
- Now when a tag is created, both workflows run:
  1. `release-publisher.yaml` → Creates GitHub release
  2. `publish.yaml` → Builds and publishes Docker images

## Testing
✅ Manually tested with tag `v28.0`:
- Docker image now available: `ghcr.io/batonogov/typesense:v28.0`

## Changes
- Added step to trigger Publish workflow after successful tag creation
- Proper error handling and logging

Fixes the issue where releases exist but Docker images are not built automatically.