### PR TITLE
Fix GitHub Actions workflow failures

### DIFF
--- a/.github/workflows/release-manager.yaml
+++ b/.github/workflows/release-manager.yaml
@@ -36,37 +36,38 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for changes
         id: changes
         run: |
           # Multiple methods to detect Dockerfile changes for reliability
           DOCKERFILE_CHANGED=false
-          
+
           # Method 1: Check current commit vs previous
           if git diff --name-only HEAD~1 HEAD | grep -q "Dockerfile"; then
             echo "🔍 Dockerfile changed in current commit (HEAD~1..HEAD)"
             DOCKERFILE_CHANGED=true
           fi
-          
+
           # Method 2: Check if this is a merge commit and look at merge changes
           if [ "$DOCKERFILE_CHANGED" = false ] && git show --name-only --format="" HEAD | grep -q "Dockerfile"; then
             echo "🔍 Dockerfile changed in merge commit"
             DOCKERFILE_CHANGED=true
           fi
-          
+
           # Method 3: Check last 3 commits for Dockerfile changes (fallback)
           if [ "$DOCKERFILE_CHANGED" = false ] && git diff --name-only HEAD~3 HEAD | grep -q "Dockerfile"; then
             echo "🔍 Dockerfile changed in recent commits (HEAD~3..HEAD)"
             DOCKERFILE_CHANGED=true
           fi
-          
+
           # Method 4: Force detection if manual trigger with force_create
           if [ "$DOCKERFILE_CHANGED" = false ] && [ "${{ github.event.inputs.force_create }}" = "true" ]; then
             echo "🔍 Force create enabled - treating as Dockerfile changed"
             DOCKERFILE_CHANGED=true
           fi
-          
+
           if [ "$DOCKERFILE_CHANGED" = true ]; then
             echo "dockerfile=true" >> $GITHUB_OUTPUT
             echo "✅ Dockerfile changes detected"
@@ -177,7 +178,7 @@ jobs:
           script: |
             const tagName = '${{ steps.tag.outputs.name }}';
             console.log(`🚀 Triggering Release Publisher workflow for tag: ${tagName}`);
-            
+
             try {
               const response = await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,
@@ -202,7 +203,7 @@ jobs:
           script: |
             const tagName = '${{ steps.tag.outputs.name }}';
             console.log(`🐳 Triggering Publish workflow for Docker image building: ${tagName}`);
-            
+
             try {
               const response = await github.rest.actions.createWorkflowDispatch({
                 owner: context.repo.owner,
@@ -415,6 +416,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
@@ -426,13 +430,34 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+
+          # Add all changes in docs directory
           git add docs/
+
+          # Check if there are any staged changes
           if git diff --staged --quiet; then
-            echo "No changes to documentation"
-          else
-            git commit -m "Update documentation"
-            git push
+            echo "No changes to documentation - skipping commit"
+            exit 0
           fi
+
+          # Commit and push changes
+          echo "Documentation changes detected, committing..."
+          git commit -m "Update documentation [skip ci]"
+
+          # Try to push, with retry logic
+          for i in {1..3}; do
+            if git push; then
+              echo "Successfully pushed documentation changes"
+              exit 0
+            else
+              echo "Push attempt $i failed, retrying in 5 seconds..."
+              sleep 5
+              git pull --rebase origin main || true
+            fi
+          done
+
+          echo "Failed to push after 3 attempts"
+          exit 1
 
   summary:
     runs-on: ubuntu-latest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -135,7 +139,7 @@
         "filename": ".github/workflows/release-manager.yaml",
         "hashed_secret": "dce23fa006b709e922df30db9e32a1b395ede3d0",
         "is_verified": false,
-        "line_number": 299
+        "line_number": 300
       }
     ],
     ".github/workflows/release-publisher.yaml": [
@@ -203,5 +207,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-01T10:36:16Z"
+  "generated_at": "2025-06-01T15:19:57Z"
 }

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -188,7 +188,7 @@ tasks:
 
         ## Available Commands
 
-        $(task --list | grep -v "task: " | sed 's/^\* /### /')
+        $(task --list | grep -v "task: " | sed 's/^\* \([^:]*\):\s*\(.*\)/### \1\n\n\2\n/')
         EOF
       - echo "Documentation generated in ./docs/README.md"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,103 @@
+# Typesense Docker Image Documentation
+
+## Available Commands
+
+### auto-release
+
+               Auto-detect and create appropriate release
+
+### backup
+
+                     Backup data from running instance
+
+### build-test-container
+
+       Build the test container
+
+### check-version
+
+              Check version and Docker image availability
+
+### clean
+
+                      Clean up test containers
+
+### create-rc
+
+                  Create release candidate (usage: task create-rc VERSION=29.0 [RC=1])
+
+### create-stable
+
+              Create stable release (usage: task create-stable VERSION=29.0)
+
+### dev
+
+                        Start development environment
+
+### dev-stop
+
+                   Stop development environment
+
+### docs
+
+                       Generate documentation
+
+### dry-run-rc
+
+                 Preview RC release creation (usage: task dry-run-rc VERSION=29.0)
+
+### dry-run-stable
+
+             Preview stable release creation (usage: task dry-run-stable VERSION=29.0)
+
+### lint
+
+                       Run linters
+
+### list-releases
+
+              List recent releases and current version
+
+### release-help
+
+               Show release management help
+
+### start-test-container
+
+       Start the test container
+
+### stop-test-container
+
+        Stop the test container
+
+### test
+
+                       Run all tests
+
+### test-api
+
+                   Run API tests
+
+### test-performance
+
+           Run performance tests
+
+### test-quick
+
+                 Run quick tests (API only, for pre-commit)
+
+### update-typesense
+
+           Update Typesense version
+
+### validate-badges
+
+            Validate README badges
+
+### validate-version
+
+           Validate current version in Dockerfile
+
+### wait-for-health
+
+            Wait for container to become healthy


### PR DESCRIPTION
This PR fixes the failing GitHub Actions workflows:

## Changes Made

- **Fixed generate-docs job in Release Manager workflow**:
  - Added proper checkout configuration with `fetch-depth: 0` and GitHub token
  - Improved error handling and retry logic for git push operations
  - Added `[skip ci]` flag to avoid infinite workflow triggers

- **Added initial documentation directory**:
  - Created docs/README.md with proper formatting for markdownlint compliance
  - Fixed documentation generation in Taskfile.yaml to meet line length requirements

## Problem Solved

The Release Manager workflow was failing on the `generate-docs` job because:
1. Missing proper git checkout configuration
2. No retry logic for git push operations
3. Missing documentation directory causing git issues

## Testing

- Pre-commit hooks pass successfully
- Documentation generation works locally
- Git operations should now be more reliable with retry logic

This should resolve the failing workflow runs visible in the Actions tab.