### PR TITLE
fix: replace deprecated check-byte-order-marker with fix-byte-order-m…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
-      - id: check-byte-order-marker
+      - id: fix-byte-order-marker
       - id: check-docstring-first
       - id: debug-statements
       - id: name-tests-test


### PR DESCRIPTION
…arker

- Updated .pre-commit-config.yaml to use fix-byte-order-marker instead of deprecated check-byte-order-marker
- This change eliminates deprecation warning and provides automatic BOM fixing instead of just detection