### PR TITLE
fix: restrict 'latest' tag to stable releases only

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -88,7 +88,9 @@ jobs:
             type=raw,value=${{ inputs.tag_name }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value={{date 'YYYYMMDD-HHmmss'}},enable=${{ github.event_name == 'workflow_dispatch' }}
           flavor: |
-            latest=${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && !contains(inputs.tag_name, 'rc'))) }}
+            # Only assign 'latest' tag to stable releases (v*.* tags without 'rc')
+            # This excludes RC versions and main branch pushes
+            latest=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc') }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/README.md
+++ b/README.md
@@ -94,19 +94,23 @@ The container includes automatic health monitoring:
 
 ### Tags
 
-- `latest` - Latest stable release
-- `v29.0` - Specific version
-- `v29.0.rc1` - Release candidates
+- `latest` - Latest stable release only (excludes RC versions)
+- `v29.0` - Specific stable version
+- `v29.0.rc1` - Release candidates (no `latest` tag)
+- `main` - Development builds from main branch
 
 ### Registries
 
 ```bash
 # GitHub Container Registry (recommended)
-ghcr.io/batonogov/typesense:latest
-
-# Docker Hub
-batonogov/typesense:latest
+ghcr.io/batonogov/typesense:latest     # Stable releases only
+ghcr.io/batonogov/typesense:v29.0      # Specific stable version
+ghcr.io/batonogov/typesense:v29.0.rc1  # Release candidate
 ```
+
+> **Note**: The `latest` tag is only assigned to stable releases
+> (e.g., `v29.0`, `v28.0`). Release candidates and development builds
+> do not receive the `latest` tag.
 
 ## Development
 

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -1,6 +1,7 @@
 # Release Management Guide
 
-This guide explains how to use the automated release system for the Typesense with Healthcheck project.
+This guide explains how to use the automated release system for the
+Typesense with Healthcheck project.
 
 ## Overview
 
@@ -18,7 +19,7 @@ Our release system consists of several automated workflows that handle:
 ### Stable Releases
 
 - **Format**: `v{major}.{minor}` (e.g., `v29.0`)
-- **Trigger**: Automatic when Dockerfile is updated with stable Typesense version
+- **Trigger**: Automatic when stable version tag is pushed
 - **Docker Tags**: `{version}`, `v{version}`, `latest`
 - **Features**: Full release notes, announcements, latest tag
 
@@ -26,7 +27,7 @@ Our release system consists of several automated workflows that handle:
 
 - **Format**: `v{major}.{minor}.rc{number}` (e.g., `v29.0.rc1`)
 - **Trigger**: Manual or scheduled (Mondays at 9 AM UTC)
-- **Docker Tags**: `{version}`, `v{version}`
+- **Docker Tags**: `{version}`, `v{version}` (NO `latest` tag)
 - **Features**: Testing issues, validation workflows
 
 ## Automatic Release Process
@@ -112,19 +113,19 @@ docker pull ghcr.io/batonogov/typesense:v29.0.rc1
 docker run -d --name typesense-test -p 8108:8108 -e TYPESENSE_API_KEY=test-key ghcr.io/batonogov/typesense:v29.0.rc1
 ```
 
-# Verify health
+## Verify health
 
 curl <http://localhost:8108/health>
 
-# Test API
+## Test API
 
 curl -H "X-TYPESENSE-API-KEY: test-key" <http://localhost:8108/collections>
 
-# Cleanup
+## Cleanup
 
 docker stop typesense-test && docker rm typesense-test
 
-````
+```bash
 
 ## Release Workflow Features
 
@@ -140,6 +141,7 @@ docker stop typesense-test && docker rm typesense-test
 - **Security**: Images signed with Cosign
 - **Registry**: Published to GitHub Container Registry (GHCR)
 - **Verification**: Automatic image accessibility checks
+- **Latest Tag**: Only assigned to stable releases (no RC versions)
 
 ### Community Engagement
 - **Announcements**: Issues created for stable releases
@@ -215,9 +217,10 @@ docker pull ghcr.io/batonogov/typesense:latest
 
 ### Tagging Strategy
 
-- **Stable**: Matches Typesense version exactly
-- **RC**: Adds `.rc{number}` suffix
-- **Latest**: Only for stable releases
+- **Stable**: Matches Typesense version exactly, gets `latest` tag
+- **RC**: Adds `.rc{number}` suffix, does NOT get `latest` tag
+- **Latest Tag**: Only assigned to stable releases when version tags are
+  pushed
 
 ### Branch Management
 
@@ -294,14 +297,15 @@ git tag -d v29.0
 git push origin :refs/tags/v29.0
 ```
 
-# Revert to previous version in Dockerfile
+## Revert to previous version in Dockerfile
 
-git revert <commit-hash>
+git revert COMMIT_HASH
 git push origin main
 
-````
+```bash
 
-### Hotfix Release
+## Hotfix Release
+
 ```bash
 # Create hotfix branch
 git checkout -b hotfix/29.0.1


### PR DESCRIPTION
- Change latest tag logic in publish.yaml workflow
- Only assign 'latest' to stable version tags (v*.* without 'rc')
- Exclude RC versions and main branch pushes from getting 'latest' tag
- Update documentation to reflect new tagging policy
- Add clarifying comments in workflow file
- Fix markdown formatting issues

Resolves issue where 'latest' was assigned to development builds and RC versions