### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/update-badges.yaml
+++ b/.github/workflows/update-badges.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.update-readme.outputs.changes == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "docs: update Typesense version badge to ${{ steps.extract-version.outputs.version }}"


### PR DESCRIPTION
Replace all @vX version tags with commit SHA pins for security.

This repo already had most actions SHA-pinned; only two `@vX` tags in `update-badges.yaml` remained:
- actions/checkout
- peter-evans/create-pull-request